### PR TITLE
feat: detailed artist view with song count and songs

### DIFF
--- a/tunaapi/models/song.py
+++ b/tunaapi/models/song.py
@@ -4,6 +4,7 @@ from .artist import Artist
 
 class Song(models.Model):
     title = models.CharField(max_length=200)
-    artist = models.ForeignKey(Artist, on_delete=models.CASCADE)
+    artist = models.ForeignKey(
+        Artist, on_delete=models.CASCADE, related_name='songs')
     album = models.CharField(max_length=200)
     length = models.PositiveIntegerField()


### PR DESCRIPTION
Added artist detail view that returns JSON in this format:


    "id": 1,
    "name": "Updated Artist Name",
    "age": 30,
    "bio": "Updated Artist Bio",
    "song_count": 4,
    "songs": [
        {
            "id": 2,
            "title": "Updated Song Title",
            "album": "Updated Album Name",
            "length": 240,
            "artist": 1
        },
        {
            "id": 3,
            "title": "My Song",
            "album": "My Album",
            "length": 180,
            "artist": 1
        },
        {
            "id": 4,
            "title": "My Song",
            "album": "My Album",
            "length": 180,
            "artist": 1
        },
        {
            "id": 5,
            "title": "My Song",
            "album": "My Album",
            "length": 180,
            "artist": 1
        }
    ]
}